### PR TITLE
fix: set odometer sensors to None if measurements is missing

### DIFF
--- a/custom_components/cupra_we_connect/sensor.py
+++ b/custom_components/cupra_we_connect/sensor.py
@@ -208,7 +208,7 @@ SENSORS: tuple[VolkswagenIdEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data["measurements"][
             "odometerStatus"
-        ].odometer.value,
+        ].odometer.value if "measurements" in data else None,
     ),
     VolkswagenIdEntityDescription(
         name="Odometer in Miles",
@@ -217,7 +217,7 @@ SENSORS: tuple[VolkswagenIdEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value=lambda data: data["measurements"][
             "odometerStatus"
-        ].odometer.value,
+        ].odometer.value if "measurements" in data else None,
     ),
 )
 


### PR DESCRIPTION
This fixes #77 by setting odometer values to none if measurements dict is missing in data dict.