### PR TITLE
Fix 403 errors after Cupra API change (app-market header)

### DIFF
--- a/custom_components/cupra_we_connect/__init__.py
+++ b/custom_components/cupra_we_connect/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, apply_app_market_header
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR, Platform.NUMBER, Platform.DEVICE_TRACKER]
 
@@ -43,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     
     await hass.async_add_executor_job(_we_connect.login)
+    apply_app_market_header(_we_connect)
     await hass.async_add_executor_job(_we_connect.update)
 
     async def async_update_data():

--- a/custom_components/cupra_we_connect/config_flow.py
+++ b/custom_components/cupra_we_connect/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import selector
 
-from .const import DOMAIN
+from .const import DOMAIN, apply_app_market_header
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +48,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     # TODO: ADD Validation on credentials
 
     await hass.async_add_executor_job(we_connect.login)
+    apply_app_market_header(we_connect)
     await hass.async_add_executor_job(we_connect.update)
 
     # vin = next(iter(we_connect.vehicles.items()))[0]

--- a/custom_components/cupra_we_connect/const.py
+++ b/custom_components/cupra_we_connect/const.py
@@ -1,3 +1,35 @@
 """Constants for the Cupra We Connect integration."""
 
 DOMAIN = "cupra_we_connect"
+
+
+def apply_app_market_header(we_connect) -> None:
+    """Cupra API headers required since VW backend change (2026-05-20).
+
+    weconnect_cupra's addToken() builds headers from scratch (Authorization only),
+    so session.headers are ignored unless we merge them in addToken.
+    """
+    session = getattr(we_connect, "session", None)
+    if session is None:
+        return
+
+    base_headers = getattr(session, "headers", None)
+    if base_headers is not None:
+        base_headers["app-market"] = "android"
+        base_headers["app-brand"] = "cupra"
+        base_headers["app-version"] = "2.15.0"
+        base_headers["origin"] = "app"
+
+    if getattr(session, "_cupra_headers_patched", False):
+        return
+
+    original_add_token = session.addToken
+
+    def add_token_with_session_headers(uri, body=None, headers=None, **kwargs):
+        merged = dict(base_headers) if base_headers is not None else {}
+        if headers:
+            merged.update(headers)
+        return original_add_token(uri, body=body, headers=merged, **kwargs)
+
+    session.addToken = add_token_with_session_headers
+    session._cupra_headers_patched = True


### PR DESCRIPTION
## Summary

Since 2026-05-20, the Cupra/Seat OLA API rejects requests to `GET /v2/users/{userId}/garage/vehicles` with **403 Forbidden** unless the client sends headers that match the MyCupra Android app.

This PR fixes integration startup and polling failures reported in #169.

## Root cause

`weconnect_cupra` builds request headers in `addToken()` from scratch (only `Authorization` and `user-id`). Setting headers on `session.headers` alone does **not** send `app-market`, `app-brand`, etc. on API calls.

## Fix

- Add `apply_app_market_header()` in `const.py` that:
  - Sets required Cupra headers on the session (`app-market`, `app-brand`, `app-version`, `origin`)
  - Wraps `session.addToken()` to merge those headers into every authenticated request
- Call it after login in `__init__.py` and `config_flow.py` (before the first `update()`)

Same approach as [pycupra v0.2.30](https://github.com/WulfgarW/pycupra/commit/0296f58e) and [evcc PR #30047](https://github.com/evcc-io/evcc/pull/30047).

## Test plan

- [x] Verified on Home Assistant 2026.5.1: integration loads without 403
- [x] Entities update again (e.g. SOC, charging state)
- [ ] Maintainer: reload integration / fresh config flow on affected account

Closes #169

Made with [Cursor](https://cursor.com)